### PR TITLE
Added Lobby List and Lobby detail pages

### DIFF
--- a/src/chigame/games/urls.py
+++ b/src/chigame/games/urls.py
@@ -5,6 +5,6 @@ from . import views
 urlpatterns = [
     path("", views.GameListView.as_view(), name="games-list"),
     path("lobby/", views.lobby_list, name="lobby-list"),
-    path("lobby/<int:pk>/", views.ViewLobbyDetails.as_view(), name ="lobby-details"),
+    path('lobby/<int:lobby_id>/', views.lobby_detail, name='lobby_detail'),
     path("<int:pk>/", views.GameDetailView.as_view(), name="game-detail"),
 ]

--- a/src/chigame/games/urls.py
+++ b/src/chigame/games/urls.py
@@ -4,4 +4,5 @@ from . import views
 
 urlpatterns = [
     path("", views.GameListView.as_view(), name="games-list"),
+    path("", views.lobby_list, name="lobby-list"),
 ]

--- a/src/chigame/games/urls.py
+++ b/src/chigame/games/urls.py
@@ -5,6 +5,6 @@ from . import views
 urlpatterns = [
     path("", views.GameListView.as_view(), name="games-list"),
     path("lobby/", views.lobby_list, name="lobby-list"),
-    path('lobby/<int:lobby_id>/', views.lobby_detail, name='lobby_detail'),
+    path("lobby/<int:pk>/", views.ViewLobbyDetails.as_view(), name ="lobby-details"),
     path("<int:pk>/", views.GameDetailView.as_view(), name="game-detail"),
 ]

--- a/src/chigame/games/urls.py
+++ b/src/chigame/games/urls.py
@@ -4,6 +4,6 @@ from . import views
 
 urlpatterns = [
     path("", views.GameListView.as_view(), name="games-list"),
-    path("", views.lobby_list, name="lobby-list"),
-    path("", views.ViewLobbyDetails.as_view(), name ="lobby-details"),
+    path("lobby/", views.lobby_list, name="lobby-list"),
+    path("lobby/<int:pk>/", views.ViewLobbyDetails.as_view(), name ="lobby-details"),
 ]

--- a/src/chigame/games/urls.py
+++ b/src/chigame/games/urls.py
@@ -4,4 +4,5 @@ from . import views
 
 urlpatterns = [
     path("", views.GameListView.as_view(), name="games-list"),
+    path("", views.ViewLobbyDetails.as_view(), name ="lobby-details"),
 ]

--- a/src/chigame/games/views.py
+++ b/src/chigame/games/views.py
@@ -1,9 +1,14 @@
 from django.views.generic import ListView
 
-from .models import Game
+from .models import Game, Lobby
 
 
 class GameListView(ListView):
     model = Game
     queryset = Game.objects.all()
     template_name = "games/game_list.html"
+
+class ViewLobbyDetails(ListView):
+    model = Lobby
+    queryset = Lobby.objects.all()
+    template_name = "games/lobby_details.html"

--- a/src/chigame/games/views.py
+++ b/src/chigame/games/views.py
@@ -1,9 +1,15 @@
 from django.views.generic import ListView
+from django.shortcuts import render, redirect, reverse
 
-from .models import Game
+from .models import *
 
 
 class GameListView(ListView):
     model = Game
     queryset = Game.objects.all()
     template_name = "games/game_list.html"
+
+def lobby_list(request):
+    lobbies = Lobby.objects.all()
+    context = {"object_list": lobbies}
+    return render(request, "games/lobby_list.html", context)

--- a/src/chigame/games/views.py
+++ b/src/chigame/games/views.py
@@ -13,10 +13,9 @@ def lobby_list(request):
     context = {"object_list": lobbies}
     return render(request, "games/lobby_list.html", context)
 
-class ViewLobbyDetails(ListView):
-    model = Lobby
-    queryset = Lobby.objects.all()
-    template_name = "games/lobby_details.html"
+def lobby_detail(request, lobby_id):
+    lobby = Lobby.objects.get(id=lobby_id)
+    return render(request, 'lobby_detail.html', {'lobby': lobby})
 
 class GameDetailView(DetailView):
     model = Game

--- a/src/chigame/games/views.py
+++ b/src/chigame/games/views.py
@@ -13,9 +13,10 @@ def lobby_list(request):
     context = {"object_list": lobbies}
     return render(request, "games/lobby_list.html", context)
 
-def lobby_detail(request, lobby_id):
-    lobby = Lobby.objects.get(id=lobby_id)
-    return render(request, 'lobby_detail.html', {'lobby': lobby})
+class ViewLobbyDetails(DetailView):	
+    model = Lobby	
+    template_name = "games/lobby_details.html"
+    context_object_name = "lobby_detail"
 
 class GameDetailView(DetailView):
     model = Game

--- a/src/templates/games/lobby_details.html
+++ b/src/templates/games/lobby_details.html
@@ -3,15 +3,15 @@
 {% block content %}
     <h1>Lobby Details</h1>
 
-    <p><strong>Name:</strong> {{ lobby.name }}</p>
-    <p><strong>Game:</strong> {{ lobby.game }}</p>
-    <p><strong>Created By:</strong> {{ lobby.created_by }}</p>
-    <p><strong>Minimum Players:</strong> {{ lobby.min_players }}</p>
-    <p><strong>Maximum Players:</strong> {{ lobby.max_players }}</p>
+    <p><strong>Name:</strong> {{ lobby_detail.name }}</p>
+    <p><strong>Game:</strong> {{ lobby_detail.game }}</p>
+    <p><strong>Created By:</strong> {{ lobby_detail.created_by }}</p>
+    <p><strong>Minimum Players:</strong> {{ lobby_detail.min_players }}</p>
+    <p><strong>Maximum Players:</strong> {{ lobby_detail.max_players }}</p>
 
     <h2>Members:</h2>
     <ul>
-        {% for member in lobby.members.all %}
+        {% for member in lobby_detail.members.all %}
             <li>{{ member.username }}</li>
         {% endfor %}
     </ul>

--- a/src/templates/games/lobby_details.html
+++ b/src/templates/games/lobby_details.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Lobby Details</title>
+</head>
+<body>
+    <h1>Lobby Details</h1>
+
+    <p><strong>Name:</strong> {{ lobby.name }}</p>
+    <p><strong>Game:</strong> {{ lobby.game }}</p>
+    <p><strong>Created By:</strong> {{ lobby.created_by }}</p>
+    <p><strong>Minimum Players:</strong> {{ lobby.min_players }}</p>
+    <p><strong>Maximum Players:</strong> {{ lobby.max_players }}</p>
+
+    <h2>Members:</h2>
+    <ul>
+        {% for member in lobby.members.all %}
+            <li>{{ member.username }}</li>
+        {% endfor %}
+    </ul>
+
+    <a href="{% url 'lobby_list' %}">Back to Lobby List</a>
+</body>
+</html>

--- a/src/templates/games/lobby_details.html
+++ b/src/templates/games/lobby_details.html
@@ -1,9 +1,6 @@
-<!DOCTYPE html>
-<html>
-<head>
-    <title>Lobby Details</title>
-</head>
-<body>
+{% extends "base.html" %}
+
+{% block content %}
     <h1>Lobby Details</h1>
 
     <p><strong>Name:</strong> {{ lobby.name }}</p>
@@ -19,6 +16,4 @@
         {% endfor %}
     </ul>
 
-    <a href="{% url 'lobby_list' %}">Back to Lobby List</a>
-</body>
-</html>
+{% endblock %}

--- a/src/templates/games/lobby_list.html
+++ b/src/templates/games/lobby_list.html
@@ -17,7 +17,7 @@
 
     {% for lobby in object_list %}
     <tr>   
-        <td>{{lobby.name}}</td>
+        <td><a href = "{% url 'lobby-details' lobby.pk %}">{{lobby.name}} </a></td>
         <td>{{lobby.game}}</td>
         <td>{{lobby.created_by}}</td>
         <td>{{lobby.members}}</td>

--- a/src/templates/games/lobby_list.html
+++ b/src/templates/games/lobby_list.html
@@ -1,0 +1,29 @@
+{% extends "base.html" %}
+
+{% block title %}
+  Lobbies
+{% endblock title %}
+{% block content %}
+  <h1>List of Lobbies</h1>
+  <table>
+    <tr>
+        <th>Lobby Name</th> 
+        <th>Game Name</th>  
+        <th>Host</th>   
+        <th>Current Members</th>  
+        <th>Min Players</th>  
+        <th>Max Players</th>        
+    </tr>
+
+    {% for lobby in object_list %}
+    <tr>   
+        <td>{{lobby.name}}</td>
+        <td>{{lobby.game}}</td>
+        <td>{{lobby.created_by}}</td>
+        <td>{{lobby.members}}</td>
+        <td>{{lobby.min_players}}</td>
+        <td>{{lobby.max_players}}</td>
+    </tr>  
+    {% endfor %}
+  </table>
+{% endblock content %}


### PR DESCRIPTION
We have implemented basic html pages for the lobby list and detail pages for each lobby. They are under the URL "lobby/". For the lobby list, since I want to display it as a table element, I did not use the default ListView from django and instead wrote a customized view method for it.