### PR TITLE
Accepting and declining friend requests and profile view reflect status of friend invitations

### DIFF
--- a/src/chigame/users/models.py
+++ b/src/chigame/users/models.py
@@ -78,10 +78,13 @@ class FriendInvitation(models.Model):
 
     def accept_invitation(self):
         sender = self.sender
+        sender_profile = UserProfile.objects.get(user__pk=sender.pk)
         receiver = self.receiver
-        sender.friends.add(receiver)
-        receiver.friends.add(sender)
+        receiver_profile = UserProfile.objects.get(user__pk=receiver.pk)
+        sender_profile.friends.add(receiver)
+        receiver_profile.friends.add(sender)
         self.accepted = True
+        self.save()
 
 
 class Group(models.Model):

--- a/src/chigame/users/models.py
+++ b/src/chigame/users/models.py
@@ -76,6 +76,13 @@ class FriendInvitation(models.Model):
     accepted = models.BooleanField(default=False)
     timestamp = models.DateTimeField(auto_now_add=True)
 
+    def accept_invitation(self):
+        sender = self.sender
+        receiver = self.receiver
+        sender.friends.add(receiver)
+        receiver.friends.add(sender)
+        self.accepted = True
+
 
 class Group(models.Model):
     """

--- a/src/chigame/users/urls.py
+++ b/src/chigame/users/urls.py
@@ -1,6 +1,7 @@
 from django.urls import path
 
 from chigame.users.views import (
+    accept_friend_invitation,
     cancel_friend_invitation,
     send_friend_invitation,
     user_detail_view,
@@ -19,6 +20,7 @@ urlpatterns = [
     path("profile/<int:pk>/", view=user_profile_detail_view, name="user-profile"),
     path("add_friend/<int:pk>", view=send_friend_invitation, name="add-friend"),
     path("cancel_friend_invitation/<int:pk>", view=cancel_friend_invitation, name="cancel-friend-invitation"),
+    path("accept_friend_invitation/<int:pk>", view=accept_friend_invitation, name="accept-friend-invitation"),
     path("user-list/", views.user_list, name="user_list"),
     path("user_history/<int:pk>", views.user_history, name="user-history"),
 ]

--- a/src/chigame/users/urls.py
+++ b/src/chigame/users/urls.py
@@ -3,6 +3,7 @@ from django.urls import path
 from chigame.users.views import (
     accept_friend_invitation,
     cancel_friend_invitation,
+    decline_friend_invitation,
     send_friend_invitation,
     user_detail_view,
     user_profile_detail_view,
@@ -21,6 +22,7 @@ urlpatterns = [
     path("add_friend/<int:pk>", view=send_friend_invitation, name="add-friend"),
     path("cancel_friend_invitation/<int:pk>", view=cancel_friend_invitation, name="cancel-friend-invitation"),
     path("accept_friend_invitation/<int:pk>", view=accept_friend_invitation, name="accept-friend-invitation"),
+    path("decline_friend_invitation/<int:pk>", view=decline_friend_invitation, name="decline-friend-invitation"),
     path("user-list/", views.user_list, name="user_list"),
     path("user_history/<int:pk>", views.user_history, name="user-history"),
 ]

--- a/src/chigame/users/views.py
+++ b/src/chigame/users/views.py
@@ -3,6 +3,7 @@ from django.contrib.auth import get_user_model
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib.messages.views import SuccessMessageMixin
+from django.db.models import Q
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
@@ -82,28 +83,30 @@ def user_profile_detail_view(request, pk):
 
 @login_required
 def send_friend_invitation(request, pk):
-    sender = User.objects.get(pk=request.user.id)
-    receiver = User.objects.get(pk=pk)
-
-    if sender.id == receiver.id:
+    curr_user = User.objects.get(pk=request.user.id)
+    other_user = User.objects.get(pk=pk)
+    if curr_user.id == other_user.id:
         messages.error(request, "You can't send friendship invitation to yourself")
         return redirect(reverse("users:user-profile", kwargs={"pk": request.user.pk}))
-    if sender.id != receiver.id:
-        friend_request, new = FriendInvitation.objects.get_or_create(sender=sender, receiver=receiver)
 
+    invitation, new = FriendInvitation.objects.filter(
+        Q(sender=curr_user, receiver=other_user) | Q(sender=other_user, receiver=curr_user)
+    ).get_or_create(defaults={"sender": curr_user, "receiver": other_user})
     if new:
         messages.success(request, "Friendship invitation sent successfully.")
         notification = Notification.objects.create(
-            actor=friend_request, receiver=receiver, type=Notification.FRIEND_REQUEST
+            actor=invitation, receiver=other_user, type=Notification.FRIEND_REQUEST
         )
+    elif invitation.sender.pk == other_user.pk:
+        messages.info(request, "You already have a pending friend invitation from this profile.")
     else:
         messages.info(request, "Friendship invitation already sent before.")
         try:
-            notification = Notification.objects.get_by_actor(friend_request, receiver=receiver)
+            notification = Notification.objects.get_by_actor(invitation, receiver=other_user)
             notification.renew_notification()
         except Notification.DoesNotExist:
             notification = Notification.objects.create(
-                actor=friend_request, receiver=receiver, type=Notification.FRIEND_REQUEST
+                actor=invitation, receiver=other_user, type=Notification.FRIEND_REQUEST
             )
     return redirect(reverse("users:user-profile", kwargs={"pk": request.user.pk}))
 

--- a/src/chigame/users/views.py
+++ b/src/chigame/users/views.py
@@ -70,6 +70,8 @@ def user_history(request, pk):
 def user_profile_detail_view(request, pk):
     try:
         profile = get_object_or_404(UserProfile, user__pk=pk)
+        if request.user.pk == pk:
+            return render(request, "users/userprofile_detail.html", {"object": profile})
         is_friend = profile.friends.filter(pk=request.user.pk).exists()
         friendship_request = None
         if not is_friend:

--- a/src/chigame/users/views.py
+++ b/src/chigame/users/views.py
@@ -136,3 +136,16 @@ def cancel_friend_invitation(request, pk):
     else:
         messages.error(request, "Something went wrong please try again later!")
     return redirect(reverse("users:user-profile", kwargs={"pk": request.user.pk}))
+
+
+@login_required
+def accept_friend_invitation(request, pk):
+    try:
+        friendship = FriendInvitation.objects.get(pk=pk)
+        if friendship.receiver.pk != request.user.pk:
+            messages.error(request, "You are not the receiver of this friend invitation ")
+        else:
+            friendship.accept_invitation()
+    except FriendInvitation.DoesNotExist:
+        messages.error(request, "This friend invitation does not exist ")
+    return redirect(reverse("users:user-profile", kwargs={"pk": request.user.pk}))

--- a/src/chigame/users/views.py
+++ b/src/chigame/users/views.py
@@ -147,5 +147,18 @@ def accept_friend_invitation(request, pk):
         else:
             friendship.accept_invitation()
     except FriendInvitation.DoesNotExist:
-        messages.error(request, "This friend invitation does not exist ")
+        messages.error(request, "This friend invitation does not exist")
+    return redirect(reverse("users:user-profile", kwargs={"pk": request.user.pk}))
+
+
+@login_required
+def decline_friend_invitation(request, pk):
+    try:
+        friendship = FriendInvitation.objects.get(pk=pk)
+        if friendship.receiver.pk != request.user.pk:
+            messages.error(request, "You are not the receiver of this friend invitation ")
+        else:
+            friendship.objects.delete()
+    except FriendInvitation.DoesNotExist:
+        messages.error(request, "This friend invitation does not exist")
     return redirect(reverse("users:user-profile", kwargs={"pk": request.user.pk}))

--- a/src/templates/users/userprofile_detail.html
+++ b/src/templates/users/userprofile_detail.html
@@ -21,13 +21,13 @@
                 {% elif is_friend %}
                   <a class="btn btn-primary">Remove Friend</a>
                 {% elif friendship_request %}
-                  {% if friendship_request.sender.pk == request.user.pk %}
-                    <a href="{% url 'users:cancel-friend-invitation' object.user.pk %}"
+                  {% if friendship_request.sender_id == request.user.pk %}
+                    <a href="{% url 'users:cancel-friend-invitation' object.user.id %}"
                        class="btn btn-primary">Cancel Friendship Request</a>
                   {% else %}
-                    <a href="{% url 'users:accept-friend-invitation' friendship_request.pk %}"
+                    <a href="{% url 'users:accept-friend-invitation' friendship_request.id %}"
                        class="btn btn-primary">Accept Friendship Request</a>
-                    <a href="{% url 'users:decline-friend-invitation' friendship_request.pk %}"
+                    <a href="{% url 'users:decline-friend-invitation' friendship_request.id %}"
                        class="btn btn-primary">Decline Friendship Request</a>
                   {% endif %}
                 {% else %}

--- a/src/templates/users/userprofile_detail.html
+++ b/src/templates/users/userprofile_detail.html
@@ -21,8 +21,15 @@
                 {% elif is_friend %}
                   <a class="btn btn-primary">Remove Friend</a>
                 {% elif friendship_request %}
-                  <a href="{% url 'users:cancel-friend-invitation' object.user.pk %}"
-                     class="btn btn-primary">Cancel Friendship Request</a>
+                  {% if friendship_request.sender.pk == request.user.pk %}
+                    <a href="{% url 'users:cancel-friend-invitation' object.user.pk %}"
+                       class="btn btn-primary">Cancel Friendship Request</a>
+                  {% else %}
+                    <a href="{% url 'users:accept-friend-invitation' friendship_request.pk %}"
+                       class="btn btn-primary">Accept Friendship Request</a>
+                    <a href="{% url 'users:decline-friend-invitation' friendship_request.pk %}"
+                       class="btn btn-primary">Decline Friendship Request</a>
+                  {% endif %}
                 {% else %}
                   <a href="{% url 'users:add-friend' object.user.pk %}"
                      class="btn btn-primary">Add Friend</a>


### PR DESCRIPTION
This handles the friending buttons in the profile views. The page displays accept or decline when visiting profile pages that send them a friend invitation. It displays remove friend if they are already friends. If they have send that user a friend invitation before, it displays cancel friend requests. If a user tries to accept/decline an invitation that does not exist or where they are not the receiver they are redirected back to their profile page with a proper error message. If they accept invitation, they become friends and if they decline the invitation is deleted.  Currently the remove friend button does not redirect to anything. This will be handled in a separate issue.

