### PR TITLE
Set format_js in pyproject.toml to be false

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,7 @@ generated-members = [
 blank_line_after_tag = "load,extends"
 close_void_tags = true
 format_css = true
-format_js = true
+format_js = false
 # TODO: remove T002 when fixed https://github.com/Riverside-Healthcare/djLint/issues/687
 ignore = "H006,H030,H031,T002"
 include = "H017,H035"


### PR DESCRIPTION
Setting format_js to false will fix the issue of the linter reformatting and breaking Django template tags in JavaScript. 