### PR TITLE
Fixed the bug in NotificationQuerySet.get_by_actor() and added tests

### DIFF
--- a/src/chigame/users/models.py
+++ b/src/chigame/users/models.py
@@ -147,10 +147,10 @@ class NotificationQuerySet(models.QuerySet):
         try:
             actor_content_type = ContentType.objects.get(model=actor._meta.model_name)
             actor_object_id = actor.pk
-            queryset = self.get(actor_content_type=actor_content_type, actor_object_id=actor_object_id, **kwargs)
-            if not include_deleted:
-                queryset = queryset.is_not_deleted()
-            return queryset
+            notification = self.get(actor_content_type=actor_content_type, actor_object_id=actor_object_id, **kwargs)
+            if not include_deleted and not notification.visible:
+                raise Notification.DoesNotExist
+            return notification
 
         except ContentType.DoesNotExist:
             raise ValueError(f"The model {actor.label} is not registered in content type")

--- a/src/chigame/users/tests/test_models.py
+++ b/src/chigame/users/tests/test_models.py
@@ -75,7 +75,12 @@ def test_notificationqueryset_get_by_actor():
         Notification.objects.get_by_actor(friendinvitation1)
         Notification.objects.get_by_actor(friendinvitation3)
 
-    assert len(Notification.objects.filter_by_actor(friendinvitation2)) == 1
+    notification = Notification.objects.get_by_actor(friendinvitation2)
+    assert notification.actor == friendinvitation2
+
+    notification.delete()
+    with pytest.raises(Notification.DoesNotExist):
+        Notification.objects.get_by_actor(friendinvitation2)
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Fixed the bug where in NotificationQuerySet.get_by_actor(), get() is used to retrieve a Notification and then is_not_deleted() is called on the return value of the get() which is a Notification object while is_not_deleted() is a method of NotificationQuerySet not Notification. I added conditional logic that raises an exception if no notification matching criteria was found and also added tests that cover the fixed bug. 