### PR TITLE
Added Support for Pagination to API endpoints supporting List views 

### DIFF
--- a/src/chigame/api/views.py
+++ b/src/chigame/api/views.py
@@ -1,6 +1,7 @@
 # from django.shortcuts import render
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import generics
+from rest_framework.pagination import PageNumberPagination
 
 from chigame.api.filters import GameFilter
 from chigame.api.serializers import GameSerializer, LobbySerializer, MessageSerializer, UserSerializer
@@ -13,6 +14,7 @@ class GameListView(generics.ListCreateAPIView):
     serializer_class = GameSerializer
     filter_backends = (DjangoFilterBackend,)  # Enable DjangoFilterBackend
     filterset_class = GameFilter  # Specify the filter class for this view
+    pagination_class = PageNumberPagination
 
 
 class GameDetailView(generics.RetrieveUpdateDestroyAPIView):
@@ -32,6 +34,7 @@ class UserFriendsAPIView(generics.RetrieveAPIView):
 class LobbyListView(generics.ListCreateAPIView):
     queryset = Lobby.objects.all()
     serializer_class = LobbySerializer
+    pagination_class = PageNumberPagination
 
 
 class LobbyDetailView(generics.RetrieveUpdateDestroyAPIView):
@@ -42,6 +45,7 @@ class LobbyDetailView(generics.RetrieveUpdateDestroyAPIView):
 class UserListView(generics.ListCreateAPIView):
     queryset = User.objects.all()
     serializer_class = UserSerializer
+    pagination_class = PageNumberPagination
 
 
 class UserDetailView(generics.RetrieveUpdateDestroyAPIView):

--- a/src/config/settings/base.py
+++ b/src/config/settings/base.py
@@ -322,6 +322,12 @@ SOCIALACCOUNT_FORMS = {"signup": "chigame.users.forms.UserSocialSignupForm"}
 # Add additional configuration below:
 # ------------------------------------------------------------------------------
 
+# REST FRAMEWORK
+REST_FRAMEWORK = {
+    "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",
+    "PAGE_SIZE": 10,
+}
+
 # Django-machina search backend:
 # https://django-machina.readthedocs.io/en/latest/getting_started.html#django-haystack-settings
 HAYSTACK_CONNECTIONS = {


### PR DESCRIPTION
Summary: When getting a list of all `Game`, `User`, `Lobby`, etc. instances, the API request previously had just return a single large list of all of the instances. This can get extremely clunky, especially if ChiGame eventually has thousands of games, as each API request for List View will return such a large amount of data. In order to fix this issue, most APIs implement pagination, where each page is a certain set amount of model instances, and the List view returned JSON is split up by these pages, making it easier to manage.

In this PR, there is added support for Pagination for the all the currently implemented List views (`/api/games`, `/api/users`, `/api/lobbies`). We set the `PAGE_SIZE` to 10 for now, but this can be changed in the future if necessary.