### PR TITLE
Fixed search bar by renaming query to query-input

### DIFF
--- a/src/chigame/games/views.py
+++ b/src/chigame/games/views.py
@@ -139,7 +139,7 @@ class GameEditView(UserPassesTestMixin, UpdateView):
 
 
 def search_results(request):
-    query = request.GET.get("query")
+    query_input = request.GET.get("query-input")
 
     """
     The Q object is an object used to encapsulate a collection of keyword
@@ -148,10 +148,10 @@ def search_results(request):
     https://docs.djangoproject.com/en/4.2/topics/db/queries/#complex-lookups-with-q-objects
     """
     object_list = Game.objects.filter(
-        Q(name__icontains=query)
-        | Q(categories__name__icontains=query)
-        | Q(people__name__icontains=query)
-        | Q(publishers__name__icontains=query)
+        Q(name__icontains=query_input)
+        | Q(categories__name__icontains=query_input)
+        | Q(people__name__icontains=query_input)
+        | Q(publishers__name__icontains=query_input)
     ).distinct()  # only show unique game objects (no duplicates)
     context = {"query_type": "Games", "object_list": object_list}
 

--- a/src/chigame/users/views.py
+++ b/src/chigame/users/views.py
@@ -186,10 +186,12 @@ def decline_friend_invitation(request, pk):
 
 
 def user_search_results(request):
-    query = request.GET.get("query")
+    query_input = request.GET.get("query-input")
     context = {"nothing_found": True, "query_type": "Users"}
-    if query:
-        users_list = UserProfile.objects.filter(Q(user__email__icontains=query) | Q(user__name__icontains=query))
+    if query_input:
+        users_list = UserProfile.objects.filter(
+            Q(user__email__icontains=query_input) | Q(user__name__icontains=query_input)
+        )
         if users_list.count() > 0:
             context.pop("nothing_found")
             context["object_list"] = users_list

--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -113,7 +113,10 @@
                       <option value="users">Users</option>
                       <!-- Add more options here -->
                     </select>
-                    <input id="query" name="query" type="text" placeholder="Search..." />
+                    <input id="query-input"
+                           name="query-input"
+                           type="text"
+                           placeholder="Search..." />
                   </form>
                 {% endblock search_bar %}
               </li>


### PR DESCRIPTION
The currently search bar does not work because the search bar input has an id of "query-input" while some other code uses "query". To fix this bug, all references to the "query" HTML element have been changed to "query-input". The games search results view and the users search results view have been changed to reflect this change.