### PR TITLE
Bug Fix: Pages numbers not displaying

### DIFF
--- a/src/templates/games/game_grid.html
+++ b/src/templates/games/game_grid.html
@@ -137,8 +137,7 @@
           </li>
           <li class="page-item">
             <a class="page-link"
-               href="?{% updated_params page=page_obj.previous_page_number %}">{{
-            page_obj.previous_page_number }}</a>
+               href="?{% updated_params page=page_obj.previous_page_number %}">{{ page_obj.previous_page_number }}</a>
           </li>
         {% else %}
           <li class="page-item disabled">
@@ -151,8 +150,7 @@
         {% if page_obj.has_next %}
           <li class="page-item">
             <a class="page-link"
-               href="?{% updated_params page=page_obj.next_page_number %}">{{ page_obj.next_page_number
-            }}</a>
+               href="?{% updated_params page=page_obj.next_page_number %}">{{ page_obj.next_page_number }}</a>
           </li>
           <li class="page-item">
             <a class="page-link"


### PR DESCRIPTION
My auto formatter caused lines that were too long to wrap around in a way that ended up breaking the display of pagination numbers. Hence, this is PR is a just a simple fix to put this all on one line.

#### broken
```html
<li class="page-item">
    <a class=...>{{
     page_obj.next_page_number }}</a>
</li>
```
<img width="1086" alt="Screenshot 2023-12-04 at 6 08 57 PM" src="https://github.com/uchicago-cs/chigame/assets/69015620/e5ab8775-0b66-4331-b1cb-8c0cc73fa55c">

#### working
```html
<li class="page-item">
    <a class="....">{{ page_obj.next_page_number}}</a>
</li>
```

<img width="455" alt="Screenshot 2023-12-04 at 6 13 25 PM" src="https://github.com/uchicago-cs/chigame/assets/69015620/af2b7675-390c-48f2-b527-73a19595917b">
