### PR TITLE
Add channels package to requirements

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,4 +8,5 @@ django-allauth==0.57.0  # https://github.com/pennersr/django-allauth
 django-crispy-forms==2.1  # https://github.com/django-crispy-forms/django-crispy-forms
 crispy-bootstrap5==0.7  # https://github.com/django-crispy-forms/crispy-bootstrap5
 django-machina==1.3.1 # https://github.com/ellmetha/django-machina
+channels==4.0.0  # https://github.com/django/channels
 Whoosh==2.7.4 # https://github.com/mchaput/whoosh


### PR DESCRIPTION
This begins to address issue #488. We need to add the channels dependency to begin implementing the rest of this tutorial: https://www.geeksforgeeks.org/realtime-chat-app-using-django/.

This will allow us to begin implementing live chat. I added it to `base.txt`. I installed and it seems to work, no issues here.