### PR TITLE
[Users Profiles + Friending] Fixed bug that deleted a FriendInvitation if a friend was removed.

### DIFF
--- a/src/chigame/users/models.py
+++ b/src/chigame/users/models.py
@@ -95,6 +95,7 @@ class FriendInvitation(models.Model):
     accepted = models.BooleanField(default=False)
     timestamp = models.DateTimeField(auto_now_add=True)
     objects = FriendInvitationManager()
+    is_deleted = models.BooleanField(default=False)
 
     def accept_invitation(self):
         sender = self.sender
@@ -104,6 +105,11 @@ class FriendInvitation(models.Model):
         sender_profile.friends.add(receiver)
         receiver_profile.friends.add(sender)
         self.accepted = True
+        self.save()
+    
+    # override default delete
+    def delete(self):
+        self.is_deleted = True
         self.save()
 
 

--- a/src/chigame/users/views.py
+++ b/src/chigame/users/views.py
@@ -175,12 +175,11 @@ def cancel_friend_invitation(request, pk):
             type=Notification.FRIEND_REQUEST,
         )
         notification.mark_as_deleted()
-    num, _ = friendship.delete()
+
+    friendship.delete()    
     notification.mark_as_deleted()
-    if num:
-        messages.success(request, "Friendship invitation cancelled successfully.")
-    else:
-        messages.error(request, "Something went wrong please try again later!")
+    messages.success(request, "Friendship invitation cancelled successfully.")
+
     return redirect(reverse("users:user-profile", kwargs={"pk": request.user.pk}))
 
 
@@ -325,9 +324,7 @@ def notification_detail(request, pk):
             messages.error(request, "You can not redirect from this notification")
             return redirect(reverse("users:user-inbox", kwargs={"pk": request.user.pk}))
         notification.mark_as_read()
-        if not notification.actor:  # when friends are removed, invitation(actor) is deleted
-            messages.error(request, "Something went wrong. This notification is invalid")
-            return redirect(reverse("users:user-profile", kwargs={"pk": request.user.pk}))
+        
         if notification.type == Notification.FRIEND_REQUEST:
             return redirect(reverse("users:user-profile", kwargs={"pk": notification.actor.sender.pk}))
     except Notification.DoesNotExist:


### PR DESCRIPTION
This pull request references Issue #413. Previously, when a friend was removed, the corresponding FriendInvitation was also deleted. This broke the notification logic, as we no longer had an assigned actor. So, I changed the deletion method to be a "soft" delete, in which we still have the invitation record in the database, meaning we can still view deleted invitation and notifications will still have their "actor"

This was done by simply adding a is_deleted flag, and creating a delete method that doesn't actually do a hard delete. 