### PR TITLE
[games] Added a way to add any game to a list of game lists the user has, besides just the Favorites game list.

### DIFF
--- a/src/chigame/games/urls.py
+++ b/src/chigame/games/urls.py
@@ -21,6 +21,9 @@ urlpatterns = [
     path("favorites/", views.FavoriteListView.as_view(), name="favorite-list"),
     path("<int:pk>/favorite/", views.add_to_favorites, name="add-to-favorites"),
     path("<int:pk>/unfavorite/", views.remove_from_favorites, name="remove-from-favorites"),
+    # custom game list handling
+    path("<int:pk>/gamelists/<int:list_pk>/add/", views.add_to_gamelist, name="add-to-gamelist"),
+    path("<int:pk>/gamelists/<int:list_pk>/remove/", views.remove_from_gamelist, name="remove-from-gamelist"),
     # games
     path("", views.GameListView.as_view(), name="game-list"),
     path("create/", views.GameCreateView.as_view(), name="game-create"),

--- a/src/chigame/games/views.py
+++ b/src/chigame/games/views.py
@@ -60,10 +60,11 @@ class GameDetailView(LoginRequiredMixin, FormMixin, DetailView):
         context = super().get_context_data(**kwargs)
         context["form"] = self.get_form()
         context["reviews"] = Review.objects.filter(game=self.object)
-        # Include the user's default 'Favorites' GameList for add/remove buttons
+        # Include the user's GameLists: default Favorites plus others
         if self.request.user.is_authenticated:
             favorites_list, _ = GameList.objects.get_or_create(name="Favorites", created_by=self.request.user)
             context["favorites_list"] = favorites_list
+            context["game_lists"] = GameList.objects.filter(created_by=self.request.user).exclude(pk=favorites_list.pk)
         return context
 
     def post(self, request, *args, **kwargs):
@@ -1091,3 +1092,19 @@ class FavoriteListView(LoginRequiredMixin, ListView):
     def get_queryset(self):
         favorites_list, _ = GameList.objects.get_or_create(name="Favorites", created_by=self.request.user)
         return favorites_list.games.all()
+
+
+@login_required
+def add_to_gamelist(request, pk, list_pk):
+    game = get_object_or_404(Game, pk=pk)
+    game_list = get_object_or_404(GameList, pk=list_pk, created_by=request.user)
+    game_list.games.add(game)
+    return redirect("game-detail", pk=pk)
+
+
+@login_required
+def remove_from_gamelist(request, pk, list_pk):
+    game = get_object_or_404(Game, pk=pk)
+    game_list = get_object_or_404(GameList, pk=list_pk, created_by=request.user)
+    game_list.games.remove(game)
+    return redirect("game-detail", pk=pk)

--- a/src/templates/games/game_detail.html
+++ b/src/templates/games/game_detail.html
@@ -1,5 +1,8 @@
 {% extends "base.html" %}
 
+{% block js %}
+  <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2/dist/umd/popper.min.js"></script>
+{% endblock js %}
 {% block title %}
   {{ game.name }} Details
 {% endblock title %}
@@ -28,13 +31,34 @@
       <div class="btn-group btn-group-lg mt-3">
         <a href="#" class="btn btn-outline-primary">Join a Match</a>
         <a href="#" class="btn btn-outline-primary">Create a Match</a>
-        {% if user.is_authenticated and favorites_list is not none %}
+        {% if user.is_authenticated %}
           {% if game in favorites_list.games.all %}
             <a href="{% url 'remove-from-favorites' pk=game.pk %}"
                class="btn btn-outline-warning">Remove from Favorites</a>
           {% else %}
             <a href="{% url 'add-to-favorites' pk=game.pk %}"
                class="btn btn-outline-success">Add to Favorites</a>
+          {% endif %}
+          {% if game_lists %}
+            <div class="btn-group ms-2">
+              <button class="btn btn-outline-primary dropdown-toggle"
+                      type="button"
+                      data-bs-toggle="dropdown"
+                      aria-expanded="false">Other Lists</button>
+              <ul class="dropdown-menu">
+                {% for glist in game_lists %}
+                  <li>
+                    {% if game in glist.games.all %}
+                      <a class="dropdown-item"
+                         href="{% url 'remove-from-gamelist' game.pk glist.pk %}">Remove from {{ glist.name }}</a>
+                    {% else %}
+                      <a class="dropdown-item"
+                         href="{% url 'add-to-gamelist' game.pk glist.pk %}">Add to {{ glist.name }}</a>
+                    {% endif %}
+                  </li>
+                {% endfor %}
+              </ul>
+            </div>
           {% endif %}
         {% endif %}
       </div>


### PR DESCRIPTION
This PR extends the Game detail page so that, in addition to the built-in “Favorites” list button, users can add or remove the current game from any other GameList they've created.



To test these changes yourself:

As an authenticated user, create a new GameList (e.g. “Board Games”) (no UI functionality for this yet, just use the /admin page to make one yourself)

Go to /games/<pk>/ 

You should see an Other Lists dropdown next to the Favorites button.

Select Add/Remove from {Whatever Game List you just created} and verify the game actually gets added/removed via the admin panel.

Closes #381 