### PR TITLE
Tournaments/Updated all templates to check for usernames after checking for names

### DIFF
--- a/src/templates/tournaments/tournament_archived_list.html
+++ b/src/templates/tournaments/tournament_archived_list.html
@@ -75,11 +75,15 @@
             {% for winner in tournament.get_all_winners %}
               <li>
                 <p>
-                  {% if winner.name %}
-                    <a href="{% url 'users:detail' winner.id %}">{{ winner.name }}</a>
-                  {% else %}
-                    <a href="{% url 'users:detail' winner.id %}">{{ winner.email }}</a>
-                  {% endif %}
+                  <a href="{% url 'users:detail' winner.id %}">
+                    {% if winner.name %}
+                      {{ winner.name }}
+                    {% elif winner.username %}
+                      {{ winner.username }}
+                    {% else %}
+                      {{ winner.email }}
+                    {% endif %}
+                  </a>
                 </p>
               </li>
             {% endfor %}
@@ -91,11 +95,15 @@
             {% for player in tournament.get_all_players %}
               <li>
                 <p>
-                  {% if player.name %}
-                    <a href="{% url 'users:detail' player.id %}">{{ player.name }}</a>
-                  {% else %}
-                    <a href="{% url 'users:detail' player.id %}">{{ player.email }}</a>
-                  {% endif %}
+                  <a href="{% url 'users:detail' player.id %}">
+                    {% if player.name %}
+                      {{ player.name }}
+                    {% elif player.username %}
+                      {{ player.username }}
+                    {% else %}
+                      {{ player.email }}
+                    {% endif %}
+                  </a>
                 </p>
               </li>
             {% endfor %}

--- a/src/templates/tournaments/tournament_detail.html
+++ b/src/templates/tournaments/tournament_detail.html
@@ -245,11 +245,15 @@
             {% for player in tournament.get_all_players %}
               {% if player.id == simulation_data.tournament_winner %}
                 <p>
-                  {% if player.name %}
-                    <strong>{{ player.name }}</strong>
-                  {% else %}
-                    <strong>{{ player.email }}</strong>
-                  {% endif %}
+                  <strong>
+                    {% if player.name %}
+                      {{ player.name }}
+                    {% elif player.username %}
+                      {{ player.username }}
+                    {% else %}
+                      {{ player.email }}
+                    {% endif %}
+                  </strong>
                 </p>
               {% endif %}
             {% endfor %}
@@ -269,6 +273,8 @@
                           {% if player.id == player_data.id %}
                             {% if player.name %}
                               {{ player.name }}
+                            {% elif player.username %}
+                              {{ player.username }}
                             {% else %}
                               {{ player.email }}
                             {% endif %}
@@ -298,6 +304,8 @@
                           {% if player.id == player_data.id %}
                             {% if player.name %}
                               {{ player.name }}
+                            {% elif player.username %}
+                              {{ player.username }}
                             {% else %}
                               {{ player.email }}
                             {% endif %}
@@ -327,6 +335,8 @@
                           {% if player.id == player_data.id %}
                             {% if player.name %}
                               {{ player.name }}
+                            {% elif player.username %}
+                              {{ player.username }}
                             {% else %}
                               {{ player.email }}
                             {% endif %}
@@ -366,11 +376,15 @@
     {% for player in tournament.get_all_players %}
       <li>
         <p>
-          {% if player.name %}
-            <a href="{% url 'users:detail' player.id %}">{{ player.name }}</a>
-          {% else %}
-            <a href="{% url 'users:detail' player.id %}">{{ player.email }}</a>
-          {% endif %}
+          <a href="{% url 'users:detail' player.id %}">
+            {% if player.name %}
+              {{ player.name }}
+            {% elif player.username %}
+              {{ player.username }}
+            {% else %}
+              {{ player.email }}
+            {% endif %}
+          </a>
         </p>
       </li>
     {% endfor %}
@@ -382,11 +396,15 @@
       {% for winner in tournament.get_all_winners %}
         <li>
           <p>
-            {% if winner.name %}
-              <a href="{% url 'users:detail' winner.id %}">{{ winner.name }}</a>
-            {% else %}
-              <a href="{% url 'users:detail' winner.id %}">{{ winner.email }}</a>
-            {% endif %}
+            <a href="{% url 'users:detail' winner.id %}">
+              {% if winner.name %}
+                {{ winner.name }}
+              {% elif winner.username %}
+                {{ winner.username }}
+              {% else %}
+                {{ winner.email }}
+              {% endif %}
+            </a>
           </p>
         </li>
       {% endfor %}
@@ -401,11 +419,15 @@
           <p>
             Match (
             {% for player in match.players.all %}
-              {% if player.name %}
-                <a href="{% url 'users:detail' player.id %}">{{ player.name }}</a>
-              {% else %}
-                <a href="{% url 'users:detail' player.id %}">{{ player.email }}</a>
-              {% endif %}
+              <a href="{% url 'users:detail' player.id %}">
+                {% if player.name %}
+                  {{ player.name }}
+                {% elif player.username %}
+                  {{ player.username }}
+                {% else %}
+                  {{ player.email }}
+                {% endif %}
+              </a>
               {% if not forloop.last %}vs.{% endif %}
             {% empty %}
               Forfeited

--- a/src/templates/tournaments/tournament_list.html
+++ b/src/templates/tournaments/tournament_list.html
@@ -75,11 +75,15 @@
             {% for winner in tournament.get_all_winners %}
               <li>
                 <p>
-                  {% if winner.name %}
-                    <a href="{% url 'users:detail' winner.id %}">{{ winner.name }}</a>
-                  {% else %}
-                    <a href="{% url 'users:detail' winner.id %}">{{ winner.email }}</a>
-                  {% endif %}
+                  <a href="{% url 'users:detail' winner.id %}">
+                    {% if winner.name %}
+                      {{ winner.name }}
+                    {% elif winner.username %}
+                      {{ winner.username }}
+                    {% else %}
+                      {{ winner.email }}
+                    {% endif %}
+                  </a>
                 </p>
               </li>
             {% endfor %}
@@ -91,11 +95,15 @@
             {% for player in tournament.get_all_players %}
               <li>
                 <p>
-                  {% if player.name %}
-                    <a href="{% url 'users:detail' player.id %}">{{ player.name }}</a>
-                  {% else %}
-                    <a href="{% url 'users:detail' player.id %}">{{ player.email }}</a>
-                  {% endif %}
+                  <a href="{% url 'users:detail' player.id %}">
+                    {% if player.name %}
+                      {{ player.name }}
+                    {% elif player.username %}
+                      {{ player.username }}
+                    {% else %}
+                      {{ player.email }}
+                    {% endif %}
+                  </a>
                 </p>
               </li>
             {% endfor %}


### PR DESCRIPTION
This PR updates the tournament templates to improve how participant information is displayed. Previously, the templates would show a user's name, then email, which could result in blank entries if neither was set. Now, the templates display the user's name if available, then username, and finally email as a last resort. This ensures that all participants are always identifiable in tournament lists, details, and archived views.

## Changes

- Updated `tournament_detail.html`, `tournament_list.html`, and `tournament_archived_list.html` to display:
  - `name` if present
  - `username` if `name` is not present
  - `email` if neither `name` nor `username` is present
- Ensured consistent participant display across all tournament-related templates

## Motivation

- Fixes an issue where some tournament participants appeared as blank entries if they had not set a name or email.
- Ensures all users are always displayed with an identifiable field.

## How to Test

1. Create users with various combinations of name, username, and email.
2. Add them to tournaments.
3. View the tournament detail, list, and archived list pages.
4. Confirm that all users are displayed with their name, username, or email (in that order of preference).
