### PR TITLE
[knowledge-base] Add Frontend Moderator Pending Guide List Page

### DIFF
--- a/src/templates/knowledge-base/moderator_pending_guides.html
+++ b/src/templates/knowledge-base/moderator_pending_guides.html
@@ -1,25 +1,44 @@
 {% extends "knowledge-base/base.html" %}
 
 {% block page-content %}
-  <h1>Pending Guides</h1>
-  <form method="get">
-    <select name="sort">
+  <h1 class="mb-4">Pending Guides</h1>
+  <form method="get" class="mb-3 d-flex align-items-center gap-2">
+    <select name="sort" class="form-select w-auto">
       <option value="">Sort by: Most Recent Update</option>
       <option value="old" {% if request.GET.sort == "old" %}selected{% endif %}>Oldest Update</option>
     </select>
-    <button type="submit">Search</button>
+    <button type="submit" class="btn btn-outline-secondary">Search</button>
   </form>
-  <ul>
-    {% for guide in pendingGuides %}
-      <li>
-        <strong>Guide for {{ guide.game_id }}</strong>
-        <br />
-        <p>Contributed by: {{ guide.author }}</p>
-        <p>Date uploaded: {{ guide.recent_upload }}</p>
-        <a href="#">Review</a>
-      </li>
-    {% empty %}
-      <li>No guides pending for review.</li>
-    {% endfor %}
-  </ul>
+  <div class="table-responsive">
+    <table class="table table-striped table-hover align-middle">
+      <thead class="table-light">
+        <tr>
+          <th>Title</th>
+          <th>Author</th>
+          <th>Date Uploaded</th>
+          <th>Status</th>
+          <th>Action</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for guide in pendingGuides %}
+          <tr>
+            <td>{{ guide.game_id.name }}</td>
+            <td>{{ guide.author.username|default:guide.author.email }}</td>
+            <td>{{ guide.recent_upload|date:"Y-m-d H:i" }}</td>
+            <td>
+              <span class="badge bg-warning text-dark">Pending</span>
+            </td>
+            <td>
+              <a href="#" class="btn btn-primary">Review</a>
+            </td>
+          </tr>
+        {% empty %}
+          <tr>
+            <td colspan="5" class="text-center">No guides pending for review.</td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
 {% endblock page-content %}


### PR DESCRIPTION
### Description

This PR significantly improves the frontend of the moderator pending guides list page. The page now features a modern, responsive Bootstrap table layout, clear column headers, status badges, and a prominent Review button, while preserving the existing sort functionality. The UI is cleaner, more readable, and easier for moderators to use. This closes issue #749 

---

### File-by-File Changes

- **src/templates/knowledge-base/moderator_pending_guides.html**  
  - Replaced the old unordered list with a Bootstrap-styled table.
  - Kept the sort dropdown and search button at the top for sorting functionality.
  - Added columns for Title, Author, Date Uploaded, Status, and Action.
  - Styled the Review button and added a status badge for clarity.
  - Improved empty state messaging.

---

### How to Test

1. **Pull this branch:**  
   ```
   git checkout knowledge-base/moderator/pending-guides-list-frontend2
   git pull
   ```

2. **Follow the same testing instructions as in PR #779:**  
   - Load the fixtures as described.
   - Log in as a moderator and visit `/knowledge-base/moderation`.
   - Verify that the pending guides list displays in a table with the new layout and features.
   - The page should look like the provided screenshot. If it does, the changes are correct.
   
<img width="1462" alt="image" src="https://github.com/user-attachments/assets/87e913e9-eaf3-4e92-a7db-55ad622d097c" />
