### PR TITLE
[API] Implementation of Achievement List View endpoint

### DIFF
--- a/src/chigame/api/serializers.py
+++ b/src/chigame/api/serializers.py
@@ -1,5 +1,6 @@
 from rest_framework import serializers
 
+from chigame.achievements.models import Achievement
 from chigame.games.models import Category, Chat, Game, Lobby, Mechanic, Message, Review, Tournament, User
 from chigame.users.models import Group
 
@@ -102,3 +103,9 @@ class ReviewSerializer(serializers.ModelSerializer):
     class Meta:
         model = Review
         fields = ["id", "user", "title", "rating", "review", "is_public", "created_at"]
+
+
+class AchievementSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Achievement
+        fields = ["id", "name", "description", "rarity", "threshold"]

--- a/src/chigame/api/urls.py
+++ b/src/chigame/api/urls.py
@@ -10,7 +10,7 @@ game_patterns = [
     path("<int:pk>/reviews/", views.GameReviewListView.as_view(), name="api-game-reviews"),
     path("<int:pk>/reviews/create/", views.ReviewCreateView.as_view(), name="api-game-review-create"),
     path("<int:game_id>/reviews/<int:pk>/", views.ReviewDetailView.as_view(), name="api-game-review-detail"),
-    path("<int:pk>/achievements/create/", views.AchievementCreateView.as_view(), name="api-game-achievement-create"),
+    path("<int:pk>/achievements/", views.AchievementListView.as_view(), name="api-game-achievements"),
 ]
 
 lobby_patterns = [

--- a/src/chigame/api/urls.py
+++ b/src/chigame/api/urls.py
@@ -10,6 +10,7 @@ game_patterns = [
     path("<int:pk>/reviews/", views.GameReviewListView.as_view(), name="api-game-reviews"),
     path("<int:pk>/reviews/create/", views.ReviewCreateView.as_view(), name="api-game-review-create"),
     path("<int:game_id>/reviews/<int:pk>/", views.ReviewDetailView.as_view(), name="api-game-review-detail"),
+    path("<int:pk>/achievements/create/", views.AchievementCreateView.as_view(), name="api-game-achievement-create"),
 ]
 
 lobby_patterns = [

--- a/src/chigame/api/views.py
+++ b/src/chigame/api/views.py
@@ -9,6 +9,7 @@ from rest_framework.views import APIView
 
 from chigame.api.filters import GameFilter
 from chigame.api.serializers import (
+    AchievementSerializer,
     CategorySerializer,
     GameSerializer,
     GroupSerializer,
@@ -213,3 +214,11 @@ class ReviewDetailView(generics.RetrieveUpdateDestroyAPIView):
         if user != self.request.user:
             raise PermissionDenied("You do not have permission to edit this review.")
         serializer.save()
+
+
+class AchievementCreateView(generics.CreateAPIView):
+    serializer_class = AchievementSerializer
+
+    def perform_create(self, serializer):
+        game_id = self.kwargs["pk"]
+        serializer.save(game_id=game_id)

--- a/src/chigame/api/views.py
+++ b/src/chigame/api/views.py
@@ -7,6 +7,7 @@ from rest_framework.permissions import IsAuthenticatedOrReadOnly
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from chigame.achievements.models import Achievement
 from chigame.api.filters import GameFilter
 from chigame.api.serializers import (
     AchievementSerializer,
@@ -216,9 +217,9 @@ class ReviewDetailView(generics.RetrieveUpdateDestroyAPIView):
         serializer.save()
 
 
-class AchievementCreateView(generics.CreateAPIView):
+class AchievementListView(generics.ListAPIView):
     serializer_class = AchievementSerializer
 
-    def perform_create(self, serializer):
+    def get_queryset(self):
         game_id = self.kwargs["pk"]
-        serializer.save(game_id=game_id)
+        return Achievement.objects.filter(game__id=game_id)


### PR DESCRIPTION
In partnership with the Achievements team, this issue aims to develop an API endpoint to allow approved users* to create ACHIEVEMENTS for a given GAME. This PR:

1. Creates a serializer for the Achievement model created by the Achievements team (Equivalent to serializer created in PR #878 )
2. Implements a new function AchievementListView() under api/views.py with a corresponding URL path "api/games/game_id/achievements/".
3. 
These two modifications allow users to view a list of achievements in the database associated with a given game.