### PR TITLE
[Knowledge-Base] Re-Add Contributor "My Guides" Table Page

### DIFF
--- a/src/chigame/knowledge_base/urls.py
+++ b/src/chigame/knowledge_base/urls.py
@@ -18,6 +18,3 @@ urlpatterns = [
     path("upload", ContributorMdUpload, name="knowledge-base-guide-upload"),
     path("guides/<int:pk>/reupload", ContributorMdUpload, name="knowledge-base-guide-reupload"),
 ]
-
-# Eventually, we should add '!<slug:username>' the contribution path so we can
-# list all the guides associated with the current user

--- a/src/templates/knowledge-base/base.html
+++ b/src/templates/knowledge-base/base.html
@@ -24,10 +24,9 @@
             <p class="mb-0">Moderator View</p>
           </a>
         {% endif %}
-        <!--
         <a href="{% url 'contributor-manage-guide' %}">
           <p class="mb-0">Contributor View</p>
-        </a> -->
+        </a>
       </div>
     </div>
     <div class="page-content">

--- a/src/templates/knowledge-base/contributor_manage_guide.html
+++ b/src/templates/knowledge-base/contributor_manage_guide.html
@@ -6,38 +6,49 @@
 {% block page-content %}
   <h1 class="contributor-title">Manage My Guides</h1>
   <a href="{% url 'knowledge-base-guide-upload' %}" class="upload-button">Create New Guide</a>
-  <table id="contributor-manage-guide">
-    <thead>
-      <tr>
-        <th>Your Guides</th>
-        <th>Unique ID</th>
-        <th>Upload Time</th>
-        <th>Status</th>
-      </tr>
-    </thead>
-    <tbody>
-      {% for guide in guides %}
+  <div class="table-responsive">
+    <table id="contributor-manage-guide"
+           class="table table-striped table-hover align-middle">
+      <thead class="table-light">
         <tr>
-          <td>
-            Guide for {{ guide.game_id }}
-            <a href="{% url 'download-guide' guide.pk %}" class="maroon">[Download]</a>
-          </td>
-          <td>{{ guide.pk }}</td>
-          <td>Last Upload: {{ guide.recent_upload }}</td>
-          <td>
-            {{ guide.get_status_display }} &nbsp;
-            {% if guide.status != 0 %}
-              <a href="{% url 'feedback-detail' guide.latest_feedback.pk %}"
-                 class="maroon">View Details</a> &nbsp;
-            {% endif %}
-            {% if guide.status == 3 %}
-              <a href="{% url 'knowledge-base-guide-reupload' guide.pk %}"
-                 class="upload-button">Resubmit</a>
-            {% endif %}
-          </td>
+          <th>Your Guides</th>
+          <th>Unique ID</th>
+          <th>Upload Time</th>
+          <th>Status</th>
+          <th>Actions</th>
         </tr>
-      {% endfor %}
-      {% if not guides %}<td colspan="4">No guides found.</td>{% endif %}
-    </tbody>
-  </table>
+      </thead>
+      <tbody>
+        {% for guide in guides %}
+          <tr>
+            <td>
+              Guide for {{ guide.game_id }}
+              <!--<a href="{% url 'download-guide' guide.pk %}" class="maroon">[Download]</a>-->
+            </td>
+            <td>{{ guide.pk }}</td>
+            <td>Last Upload: {{ guide.recent_upload }}</td>
+            <td>
+              {% if guide.status == 0 %}
+                <span class="badge bg-warning text-light">{{ guide.get_status_display }}&nbsp;</span>
+              {% elif guide.status == 1 %}
+                <span class="badge bg-success">{{ guide.get_status_display }}&nbsp;</span>
+              {% elif guide.status == 2 %}
+                <span class="badge bg-danger text-dark">{{ guide.get_status_display }}&nbsp;</span>
+              {% elif guide.status == 3 %}
+                <a href="{% url 'knowledge-base-guide-reupload' guide.pk %}"
+                   class="upload-button">Resubmit</a>
+              {% endif %}
+            </td>
+            <td>
+              {% if guide.status != 0 %}
+                <a href="{% url 'feedback-detail' guide.latest_feedback.pk %}"
+                   class="maroon">View Details</a> &nbsp;
+              {% endif %}
+            </td>
+          </tr>
+        {% endfor %}
+        {% if not guides %}<td colspan="4">No guides found.</td>{% endif %}
+      </tbody>
+    </table>
+  </div>
 {% endblock page-content %}


### PR DESCRIPTION
## Description
This PR closes Issue #896. The Contributor tab in the landing guide navigation bar has been re-added, and it now redirects to "knowledge-base/manage-my-guides". The "My Guides" table has also been updated to better match the Bootstrap layout of the Moderator Guides table as described in PR #870.

## File by File Changes
- **src/templates/base.html**
    - added html to display the Contributor view navigation bar item
    - added href to redirect to the "manage-my-guides" url
    - added some Bootstrap formatting to the guides table

## How to test
Testing for this PR is the same as for PR #870 and PR #779.
1. **Pull this branch**
2. **Follow instructions from PR #779**
   - Load the fixtures as described.
   - Log in as admin or any contributor account.
   - Visit 'knowledge-base/manage-my-guides'.
   - The page should look like the screenshot provided below:

<img width="1680" alt="Screenshot 2025-05-12 at 7 23 15 PM" src="https://github.com/user-attachments/assets/77366767-8baf-4b84-b5eb-ca6e4a45e9a9" />

