### PR TITLE
Adding Dictionary API for Word Validation

### DIFF
--- a/src/sandbox/words-game/README.md
+++ b/src/sandbox/words-game/README.md
@@ -1,3 +1,6 @@
 # Words-Game
 Word list based on the 5-letter word list compiled by shmookey.
 https://gist.github.com/shmookey/b28e342e1b1756c4700f42f17102c2ff
+
+Dictionary API for known words
+https://dictionaryapi.dev/

--- a/src/sandbox/words-game/game.js
+++ b/src/sandbox/words-game/game.js
@@ -28,6 +28,7 @@ let word = "";
 let guessedWordCount = 0;
 let allowedWords = [];
 let gameOver = false;
+const url = "https://api.dictionaryapi.dev/api/v2/entries/en/";
 
 //color constants
 const COLOR_CORRECT = "rgb(83, 141, 78)";
@@ -163,8 +164,28 @@ function getTileColor(letter, index) {
     return COLOR_OFF;
 }
 
+//Check if Word is a Valid Word
+async function isValidWord(word) {
+    const word_url = url + word;
+    try {
+        const response = await fetch(word_url);
+
+        if (response.status === 404) {
+            showNotification(`"${word}" Is Not A Valid Word.`);
+            return false;
+        }
+
+        const json = await response.json();
+        console.log("Dictionary API response:", json);
+        return true;
+    } catch (error) {
+        console.error("Error checking word:", error.message);
+        return false;
+    }
+}
+
 //Handles running the submission of each word
-function handleSubmitWord() {
+async function handleSubmitWord() {
     if (gameOver) {
         return;
     }
@@ -177,8 +198,8 @@ function handleSubmitWord() {
 
     const currentWord = currentWordArr.join("").toLowerCase();
 
-    if (!allowedWords.includes(currentWord)) {
-        window.alert("Word is not recognised!");
+    const valid = await isValidWord(currentWord);
+    if (!valid) {
         return;
     }
 

--- a/src/sandbox/words-game/solo.js
+++ b/src/sandbox/words-game/solo.js
@@ -28,6 +28,8 @@ let word = "";
 let guessedWordCount = 0;
 let allowedWords = [];
 let gameOver = false;
+const url = "https://api.dictionaryapi.dev/api/v2/entries/en/";
+
 
 //color constants
 const COLOR_CORRECT = "rgb(83, 141, 78)";
@@ -169,8 +171,27 @@ function getTileColor(letter, index) {
     return COLOR_OFF;
 }
 
+async function isValidWord(word) {
+    const word_url = url + word;
+    try {
+        const response = await fetch(word_url);
+
+        if (response.status === 404) {
+            showNotification(`"${word}" Is Not a Valid Word.`);
+            return false;
+        }
+
+        const json = await response.json();
+        console.log("Dictionary API response:", json);
+        return true;
+    } catch (error) {
+        console.error("Error checking word:", error.message);
+        return false;
+    }
+}
+
 //Handles running the submission of each word
-function handleSubmitWord() {
+async function handleSubmitWord() {
     if (gameOver) {
         return;
     }
@@ -183,8 +204,8 @@ function handleSubmitWord() {
 
     const currentWord = currentWordArr.join("").toLowerCase();
 
-    if (!allowedWords.includes(currentWord)) {
-        window.alert("Word is not recognised!");
+    const valid = await isValidWord(currentWord);
+    if (!valid) {
         return;
     }
 


### PR DESCRIPTION
Implemented Dictionary API validation:
Dictionary API - https://dictionaryapi.dev/

I created the isValidWord function and sent an asynchronous request to the Dictionary API to check if the provided word exists in the dictionary.

The word is passed to the API endpoint, and a fetch request is made. If the API returns a 404 response (meaning the word is not found), it would return False. If the word exists, the API response is parsed as JSON, and the function returns True.

This function is used in the handleSubmitWord function, where the current word entered by the user is checked for validity before proceeding with game logic.

The await keyword ensures the game logic waits for the API call to finish before continuing, providing a smoother flow for word validation.