### PR TITLE
[Word game] Creating URL for Word Game on Chigame and Embedding it

### DIFF
--- a/src/chigame/games/urls.py
+++ b/src/chigame/games/urls.py
@@ -45,4 +45,6 @@ urlpatterns = [
     # placeholder game
     path("lobby/<int:pk>/coinflip", views.coin_flip_game, name="placeholder-game"),
     path("<int:pk>/", views.GameDetailView.as_view(), name="game-detail"),
+    # Word Game
+    path("wordle/", views.wordle_game_page, name="wordle-game"),
 ]

--- a/src/chigame/games/views.py
+++ b/src/chigame/games/views.py
@@ -1,8 +1,10 @@
 import os
 import xml.etree.ElementTree as ET
+from datetime import datetime, timedelta
 from functools import wraps
 from random import choice
 
+import jwt
 import requests
 from django.conf import settings
 from django.contrib import messages
@@ -1178,3 +1180,22 @@ def remove_from_gamelist(request, pk, list_pk):
     game_list = get_object_or_404(GameList, pk=list_pk, created_by=request.user)
     game_list.games.remove(game)
     return redirect("game-detail", pk=pk)
+
+
+# =============== Word Game Views ===============
+
+
+@login_required
+def wordle_game_page(request):
+    # Generate a short-lived JWT for secure identification
+    payload = {
+        "user_id": request.user.id,
+        "username": request.user.username,
+        "exp": datetime.now(timezone.utc) + timedelta(minutes=30),
+    }
+    token = jwt.encode(payload, settings.SECRET_KEY, algorithm="HS256")
+
+    # GitHub Pages game URL + token
+    iframe_url = f"https://zhejiej.github.io/Words-Game//?token={token}"
+
+    return render(request, "games/wordle.html", {"iframe_url": iframe_url})

--- a/src/templates/games/wordle.html
+++ b/src/templates/games/wordle.html
@@ -1,0 +1,10 @@
+{% extends "base.html" %}
+
+{% block content %}
+  <h2>Play Wordle</h2>
+  <iframe src="{{ iframe_url }}"
+          class="wordle-iframe"
+          width="100%"
+          height="800px"
+          allowfullscreen></iframe>
+{% endblock content %}

--- a/src/templates/games/wordle.html
+++ b/src/templates/games/wordle.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 
 {% block content %}
-  <h2>Play Wordle</h2>
+  <h2>Play Word Game</h2>
   <iframe src="{{ iframe_url }}"
           class="wordle-iframe"
           width="100%"


### PR DESCRIPTION
Added a games/wordle URL path in urls.py and created a view for it that uses iframe to take the Word Game we are hosting on a separate repo and send that to the wordle.html. Created a wordle.html that uses iframe and takes the URL given by views.py to display the Word Game on Chigame. On /games/wordle/

![Screenshot 2025-05-14 190946](https://github.com/user-attachments/assets/4fbbb564-bf57-4b3e-90a5-6eb6a60a23e8)
