### PR TITLE
[Interactive Fiction] Fixing misredirection

### DIFF
--- a/src/chigame/games/views.py
+++ b/src/chigame/games/views.py
@@ -78,10 +78,8 @@ class GameDetailView(LoginRequiredMixin, FormMixin, DetailView):
         context["popularity"] = self.object.reviews.count()
         context["avg_rating"] = self.object.reviews.filter(is_public=True).aggregate(Avg("rating"))["rating__avg"]
 
-        #FOR IF/twine GAMES
-        context["is_twine_game"] = (
-            self.object.twine_file.name.endswith(".html") if self.object.twine_file else False
-        )
+        # FOR IF/twine GAMES
+        context["is_twine_game"] = self.object.twine_file.name.endswith(".html") if self.object.twine_file else False
         # Include the user's GameLists: default Favorites plus others
         if self.request.user.is_authenticated:
             favorites_list, _ = GameList.objects.get_or_create(name="Favorites", created_by=self.request.user)

--- a/src/chigame/games/views.py
+++ b/src/chigame/games/views.py
@@ -77,6 +77,11 @@ class GameDetailView(LoginRequiredMixin, FormMixin, DetailView):
         context["reviews"] = Review.objects.filter(game=self.object)
         context["popularity"] = self.object.reviews.count()
         context["avg_rating"] = self.object.reviews.filter(is_public=True).aggregate(Avg("rating"))["rating__avg"]
+
+        #FOR IF/twine GAMES
+        context["is_twine_game"] = (
+            self.object.twine_file.name.endswith(".html") if self.object.twine_file else False
+        )
         # Include the user's GameLists: default Favorites plus others
         if self.request.user.is_authenticated:
             favorites_list, _ = GameList.objects.get_or_create(name="Favorites", created_by=self.request.user)

--- a/src/chigame/games/views.py
+++ b/src/chigame/games/views.py
@@ -66,8 +66,6 @@ class GameDetailView(LoginRequiredMixin, FormMixin, DetailView):
     # for twine files, redirect to different IF view
     def dispatch(self, request, *args, **kwargs):
         self.object = self.get_object()
-        if self.object.twine_file.name.endswith(".html"):
-            return redirect("interactive-fiction-detail", pk=self.object.pk)
         return super().dispatch(request, *args, **kwargs)
 
     def get_success_url(self):

--- a/src/config/settings/base.py
+++ b/src/config/settings/base.py
@@ -409,8 +409,3 @@ MACHINA_DEFAULT_AUTHENTICATED_USER_FORUM_PERMISSIONS = [
 # https://channels.readthedocs.io/en/stable/topics/channel_layers.html
 CHANNEL_LAYERS = {"default": {"BACKEND": "channels.layers.InMemoryChannelLayer"}}
 
-#for interactive fiction
-import os
-
-MEDIA_URL = "/media/"
-MEDIA_ROOT = os.path.join(BASE_DIR, "media")

--- a/src/config/settings/base.py
+++ b/src/config/settings/base.py
@@ -408,4 +408,3 @@ MACHINA_DEFAULT_AUTHENTICATED_USER_FORUM_PERMISSIONS = [
 # ------------------------------------------------------------------------------
 # https://channels.readthedocs.io/en/stable/topics/channel_layers.html
 CHANNEL_LAYERS = {"default": {"BACKEND": "channels.layers.InMemoryChannelLayer"}}
-

--- a/src/config/settings/base.py
+++ b/src/config/settings/base.py
@@ -408,3 +408,9 @@ MACHINA_DEFAULT_AUTHENTICATED_USER_FORUM_PERMISSIONS = [
 # ------------------------------------------------------------------------------
 # https://channels.readthedocs.io/en/stable/topics/channel_layers.html
 CHANNEL_LAYERS = {"default": {"BACKEND": "channels.layers.InMemoryChannelLayer"}}
+
+#for interactive fiction
+import os
+
+MEDIA_URL = "/media/"
+MEDIA_ROOT = os.path.join(BASE_DIR, "media")

--- a/src/templates/games/game_detail.html
+++ b/src/templates/games/game_detail.html
@@ -95,7 +95,7 @@
           </p>
         {% endif %}
         <p>{{ game.description|linebreaksbr }}</p>
-        {% if game.twine_file and game.twine_file.name.endswith:".html" %}
+        {% if is_twine_game %}
           <h3>Play Twine Game</h3>
           <a href="{{ game.twine_file.url }}"
              target="_blank"

--- a/src/templates/games/game_detail.html
+++ b/src/templates/games/game_detail.html
@@ -95,9 +95,9 @@
           </p>
         {% endif %}
         <p>{{ game.description|linebreaksbr }}</p>
-        {% if uploaded_file_url %}
+        {% if game.twine_file and game.twine_file.name.endswith:".html" %}
           <h3>Play Twine Game</h3>
-          <a href="{{ uploaded_file_url }}"
+          <a href="{{ game.twine_file.url }}"
              target="_blank"
              class="btn btn-success">Open Game in New Tab</a>
         {% endif %}


### PR DESCRIPTION
Clicking on a Twine game in the search results now leads to a Create Game Template instead of the detail page as it did before (probably the result of push after that code was implemented) 

This PR is related to issue #992 

The code was so that clicking on the IF game leads to the detail page instead of the creation template, primarily editing the game_detail html and the game view code to make sure the redirect doesn't happen.

It should look like this when a game is clicked on:
<img width="972" alt="Image" src="https://github.com/user-attachments/assets/8d38330e-69a1-4155-944d-3991b10d0a4b" />