### PR TITLE
[Adding Games - Checkers] Fix easy bot functionality

### DIFF
--- a/src/sandbox/checkers-prototype/game.js
+++ b/src/sandbox/checkers-prototype/game.js
@@ -541,7 +541,7 @@ function getPiece(x, y) {
 }
 
 // end the turn
-function endTurn() {
+function endTurn(scene) {
   stopPlayerTimer(); // stop current timer
   // remove the selected piece and its highlight
   if (selectedPiece) {
@@ -554,8 +554,28 @@ function endTurn() {
   startPlayerTimer(); // start next player’s timer
   // remove the highlight after a move is made
   clearHighlightedTiles();
-}
 
+  // reset draw offer if it was made by the current player
+  if (drawOffered && drawOfferedBy === currentPlayer) {
+    const gameOverPrompts = document.getElementById('gameOverPrompts');
+    const gameOverMessage = document.getElementById('gameOverMessage');
+    const drawBtn = document.getElementById('drawBtn');
+    const declineDrawBtn = document.getElementById('declineDrawBtn');
+    drawOffered = false;
+    drawOfferedBy = null;
+    gameOverMessage.textContent = '';
+    gameOverMessage.classList.remove('show');
+    gameOverPrompts.classList.remove('show');
+    drawBtn.textContent = 'Offer Draw';
+    declineDrawBtn.style.display = 'none';
+  }
+
+  //if black and bot is on, schedule bot move
+  if (vsEasyBot && currentPlayer === darkPiece){
+    //delay so user has time to process bot move after their own
+    scene.time.delayedCall(300, easyBot, [scene], scene);
+  }
+}
 
 // helper function to clear all the highlighted tiles
 function clearHighlightedTiles() {
@@ -686,69 +706,6 @@ function highlightValidMoves(scene, piece) {
 
       highlightedTiles.push(highlight);
     }
-  }
-}
-
-// generate a random valid move
-// after we finish implementing a bot, we could it make give an actual good suggestion
-function giveHint() {
-  // get all of the pieces of the current player
-  const playerPieces = pieces.filter((p) => p.color === currentPlayer);
-  let validMoves = [];
-
-  // get all of the valid moves for all of the pieces
-  for (const piece of playerPieces) {
-    for (let y = 0; y < BOARD_SIZE; y++) {
-      for (let x = 0; x < BOARD_SIZE; x++) {
-        if (!getPiece(x, y) && isValidMove(piece, x, y)) {
-          // add it to the array
-          // (this is a shorthand to initialize objects btw if you don't know)
-          validMoves.push({ piece, x, y });
-        }
-      }
-    }
-  }
-
-  // We have yet to implement a feature where it checks whether there are valid
-  // moves remaining for a player after each turn. In a real game of checkers
-  // if there are no moves left, the player loses the game.
-  if (validMoves.length > 0) {
-    // Math.random() only returns floating point from 0 to 1 and would require a
-    // separate helper function to return a random index from the array...
-    // https://docs.phaser.io/phaser/concepts/math
-    // phaser.math.rnd.pick() selects a random element from the array
-    const randomHint = Phaser.Math.RND.pick(validMoves);
-    // unlike chess, where there's rank and file, I don't think there's a proper
-    // way of calling a specific square on the board. For now, I just have it return
-    // the row and col on the matrix.
-    alert(
-      `Hint: Move ${currentPlayer === lightPiece ? 'red' : 'black'} piece at (row ${
-        randomHint.piece.y
-      }, column ${randomHint.piece.x}) to (row ${randomHint.y}, column ${randomHint.x})`
-    );
-  } else {
-    // in a normal checkers game, the player loses if there are no moves left
-    alert('No valid moves.');
-  }
-
-  // reset draw offer if it was made by the current player
-  if (drawOffered && drawOfferedBy === currentPlayer) {
-    const gameOverPrompts = document.getElementById('gameOverPrompts');
-    const gameOverMessage = document.getElementById('gameOverMessage');
-    const drawBtn = document.getElementById('drawBtn');
-    const declineDrawBtn = document.getElementById('declineDrawBtn');
-    drawOffered = false;
-    drawOfferedBy = null;
-    gameOverMessage.textContent = '';
-    gameOverMessage.classList.remove('show');
-    gameOverPrompts.classList.remove('show');
-    drawBtn.textContent = 'Offer Draw';
-    declineDrawBtn.style.display = 'none';
-  }
-  //if black and bot is on, schedule bot move
-  if (vsEasyBot && currentPlayer === darkPiece){
-    //delay so user has time to process bot movw after their own
-    scene.time.delayedCall(300, easyBot, [scene], scene);
   }
 }
 

--- a/src/sandbox/checkers-prototype/index.html
+++ b/src/sandbox/checkers-prototype/index.html
@@ -28,6 +28,7 @@
         <button id="forfeitBtn" class="btn">Forfeit</button>
         <button id="drawBtn" class="btn">Offer Draw</button>
         <button id="declineDrawBtn" class="btn">Decline Draw</button>
+        <button id="toggle-bot" class="btn">Play vs Bot: ON</button>
         <button class="btn"
                 onclick="window.open('https://github.com/uchicago-cs/chigame/wiki/Adding-Games-~-Checkers-Rules', '_blank')">
           Read Rules


### PR DESCRIPTION
To address issue #1128, this PR fixes the easy bot, which currently does not work on the dev branch. All the changes are in game.js in the checkers-prototype directory. The first fix is removing duplicate versions of functions including clearHighlightedTiles and highlightValidMoves. The second fix is moving the endTurn logic that was previously in giveHint so that the endTurn and giveHint functions now both contain the code they should.

For testing this PR, make sure to run the checkers prototype on localhost (python3 -m http.server 8000) as opposed to opening index.html as a static file.