### PR TITLE
[Leaderboards] Linking Chigame home page to Leaderboards landing page

### DIFF
--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -101,6 +101,9 @@
               <li class="nav-item">
                 <a class="nav-link" href="{% url 'knowledge-base' %}">Knowledge Base</a>
               </li>
+              <li class="nav-item">
+                <a class="nav-link" href="{% url 'leaderboards_landing' %}">Leaderboards</a>
+              </li>
               {% if request.user.is_authenticated %}
                 <li class="nav-item">
                   <a class="nav-link" href="{% url 'game-list' %}">Games</a>


### PR DESCRIPTION
Added 'Leaderboards' button to nav bar in templates/base.html. The button is located left of 'Sign Up' at the top of the page, and directs the user to chigame/leaderboards, the landing page for our leaderboards.