### PR TITLE
[Game Management] Creating game statistics page with period filtering

### DIFF
--- a/src/chigame/games/models.py
+++ b/src/chigame/games/models.py
@@ -1225,3 +1225,6 @@ class GameQueueEntry(models.Model):
 
     def __str__(self):
         return f"{self.game.name} (pos {self.position})"
+
+
+# Game Stat Model Implementation

--- a/src/chigame/games/urls.py
+++ b/src/chigame/games/urls.py
@@ -37,7 +37,7 @@ urlpatterns = [
     # matches
     path("<int:pk>/match/create/", views.MatchCreateView.as_view(), name="match-create"),
     path("<int:pk>/match/join/", views.join_match, name="match-join"),
-    path("games/<int:game_id>/history/", views.game_history_view, name="game_history"),
+    path("games/<int:game_id>/history/", views.GameHistoryView.as_view(), name="game_history"),
     path("lobby/<int:pk>/code/", views.MatchCodeView.as_view(), name="match-code"),
     # interactive fiction
     path("interactive-fiction/", views.IFGameCreateView.as_view(), name="interactive-fiction-create"),

--- a/src/chigame/games/views.py
+++ b/src/chigame/games/views.py
@@ -1817,18 +1817,18 @@ def add_review(request, pk):
 
 
 @login_required
-def add_to_favorites(request, pk):
+def add_to_favorites(request, game_id):
     """Add a game to the current user's 'Favorites' list."""
-    game = get_object_or_404(Game, pk=pk)
+    game = get_object_or_404(Game, pk=game_id)
     favorites_list, _ = GameList.objects.get_or_create(name="Favorites", created_by=request.user)
     favorites_list.games.add(game)
     return redirect("favorite-list")
 
 
 @login_required
-def remove_from_favorites(request, pk):
+def remove_from_favorites(request, game_id):
     """Remove a game from the current user's 'Favorites' list."""
-    game = get_object_or_404(Game, pk=pk)
+    game = get_object_or_404(Game, pk=game_id)
     try:
         favorites_list = GameList.objects.get(name="Favorites", created_by=request.user)
         favorites_list.games.remove(game)
@@ -2008,12 +2008,59 @@ def create_game_history_entry(user, match):
 @login_required
 def game_history_view(request, game_id):
     game = get_object_or_404(Game, id=game_id)
-    entries = (
-        GameHistory.objects.filter(user=request.user, match__game=game)
-        .select_related("match")
-        .order_by("-date_played")
-    )
-    return render(request, "games/game_history.html", {"game": game, "entries": entries})
+    period = request.GET.get("period", "all")  # Default to "all" if no period is specified
+
+    entries = GameHistory.objects.filter(user=request.user, match__game=game)
+
+    if period != "all":
+        today = timezone.now().date()
+        if period == "7days":
+            start_date = today - timedelta(days=7)
+        elif period == "30days":
+            start_date = today - timedelta(days=30)
+        elif period == "3months":
+            start_date = today - timedelta(days=90)
+        elif period == "6months":
+            start_date = today - timedelta(days=180)
+        elif period == "12months":
+            start_date = today - timedelta(days=365)
+        else:  # Default to all if period is unknown
+            start_date = None
+
+        if start_date:
+            entries = entries.filter(date_played__gte=start_date)
+
+    entries = entries.select_related("match").order_by("-date_played")
+
+    # Calculate statistics
+    total_played = entries.count()
+    wins = entries.filter(result=GameHistory.WIN).count()
+    losses = entries.filter(result=GameHistory.LOSE).count()
+    draws = entries.filter(result=GameHistory.DRAW).count()
+    incomplete = entries.filter(result=GameHistory.INCOMPLETE).count()
+
+    win_rate = (wins / total_played) * 100 if total_played > 0 else 0
+
+    context = {
+        "game": game,
+        "entries": entries,
+        "selected_period": period,
+        "total_played": total_played,
+        "wins": wins,
+        "losses": losses,
+        "draws": draws,
+        "incomplete": incomplete,
+        "win_rate": win_rate,
+        "period_options": [
+            {"value": "all", "label": "All Time"},
+            {"value": "7days", "label": "Last 7 Days"},
+            {"value": "30days", "label": "Last 30 Days"},
+            {"value": "3months", "label": "Last 3 Months"},
+            {"value": "6months", "label": "Last 6 Months"},
+            {"value": "12months", "label": "Last 12 Months"},
+        ],
+    }
+    return render(request, "games/game_history.html", context)
 
 
 class MatchStatsView(DetailView):

--- a/src/chigame/games/views.py
+++ b/src/chigame/games/views.py
@@ -2005,62 +2005,63 @@ def create_game_history_entry(user, match):
     )
 
 
-@login_required
-def game_history_view(request, game_id):
-    game = get_object_or_404(Game, id=game_id)
-    period = request.GET.get("period", "all")  # Default to "all" if no period is specified
+@method_decorator(login_required, name="dispatch")
+class GameHistoryView(View):
+    def get(self, request, game_id):
+        game = get_object_or_404(Game, id=game_id)
+        period = request.GET.get("period", "all")  # Default to "all" if no period is specified
 
-    entries = GameHistory.objects.filter(user=request.user, match__game=game)
+        entries = GameHistory.objects.filter(user=request.user, match__game=game)
 
-    if period != "all":
-        today = timezone.now().date()
-        if period == "7days":
-            start_date = today - timedelta(days=7)
-        elif period == "30days":
-            start_date = today - timedelta(days=30)
-        elif period == "3months":
-            start_date = today - timedelta(days=90)
-        elif period == "6months":
-            start_date = today - timedelta(days=180)
-        elif period == "12months":
-            start_date = today - timedelta(days=365)
-        else:  # Default to all if period is unknown
-            start_date = None
+        if period != "all":
+            today = timezone.now().date()
+            if period == "7days":
+                start_date = today - timedelta(days=7)
+            elif period == "30days":
+                start_date = today - timedelta(days=30)
+            elif period == "3months":
+                start_date = today - timedelta(days=90)
+            elif period == "6months":
+                start_date = today - timedelta(days=180)
+            elif period == "12months":
+                start_date = today - timedelta(days=365)
+            else:  # Default to all if period is unknown
+                start_date = None
 
-        if start_date:
-            entries = entries.filter(date_played__gte=start_date)
+            if start_date:
+                entries = entries.filter(date_played__gte=start_date)
 
-    entries = entries.select_related("match").order_by("-date_played")
+        entries = entries.select_related("match").order_by("-date_played")
 
-    # Calculate statistics
-    total_played = entries.count()
-    wins = entries.filter(result=GameHistory.WIN).count()
-    losses = entries.filter(result=GameHistory.LOSE).count()
-    draws = entries.filter(result=GameHistory.DRAW).count()
-    incomplete = entries.filter(result=GameHistory.INCOMPLETE).count()
+        # Calculate statistics
+        total_played = entries.count()
+        wins = entries.filter(result=GameHistory.WIN).count()
+        losses = entries.filter(result=GameHistory.LOSE).count()
+        draws = entries.filter(result=GameHistory.DRAW).count()
+        incomplete = entries.filter(result=GameHistory.INCOMPLETE).count()
 
-    win_rate = (wins / total_played) * 100 if total_played > 0 else 0
+        win_rate = (wins / total_played) * 100 if total_played > 0 else 0
 
-    context = {
-        "game": game,
-        "entries": entries,
-        "selected_period": period,
-        "total_played": total_played,
-        "wins": wins,
-        "losses": losses,
-        "draws": draws,
-        "incomplete": incomplete,
-        "win_rate": win_rate,
-        "period_options": [
-            {"value": "all", "label": "All Time"},
-            {"value": "7days", "label": "Last 7 Days"},
-            {"value": "30days", "label": "Last 30 Days"},
-            {"value": "3months", "label": "Last 3 Months"},
-            {"value": "6months", "label": "Last 6 Months"},
-            {"value": "12months", "label": "Last 12 Months"},
-        ],
-    }
-    return render(request, "games/game_history.html", context)
+        context = {
+            "game": game,
+            "entries": entries,
+            "selected_period": period,
+            "total_played": total_played,
+            "wins": wins,
+            "losses": losses,
+            "draws": draws,
+            "incomplete": incomplete,
+            "win_rate": win_rate,
+            "period_options": [
+                {"value": "all", "label": "All Time"},
+                {"value": "7days", "label": "Last 7 Days"},
+                {"value": "30days", "label": "Last 30 Days"},
+                {"value": "3months", "label": "Last 3 Months"},
+                {"value": "6months", "label": "Last 6 Months"},
+                {"value": "12months", "label": "Last 12 Months"},
+            ],
+        }
+        return render(request, "games/game_history.html", context)
 
 
 class MatchStatsView(DetailView):

--- a/src/templates/games/game_history.html
+++ b/src/templates/games/game_history.html
@@ -4,6 +4,74 @@
   <div class="container mt-5">
     <h1 class="display-4 mb-4">Game History for {{ game.name }}</h1>
     <a href="{% url 'game-detail' game.id %}" class="btn btn-primary mb-4">← Return to Game Detail</a>
+    <form method="get" class="mb-4">
+      <div class="row">
+        <div class="col-md-4">
+          <label for="periodSelect" class="form-label">Select Period:</label>
+          <select name="period"
+                  id="periodSelect"
+                  class="form-select"
+                  onchange="this.form.submit()">
+            {% for option in period_options %}
+              <option value="{{ option.value }}"
+                      {% if option.value == selected_period %}selected{% endif %}>{{ option.label }}</option>
+            {% endfor %}
+          </select>
+        </div>
+      </div>
+    </form>
+    <div class="row mb-4">
+      <div class="col-md-3">
+        <div class="card text-center">
+          <div class="card-body">
+            <h5 class="card-title">Total Played</h5>
+            <p class="card-text fs-4">{{ total_played }}</p>
+          </div>
+        </div>
+      </div>
+      <div class="col-md-3">
+        <div class="card text-center text-success">
+          <div class="card-body">
+            <h5 class="card-title">Wins</h5>
+            <p class="card-text fs-4">{{ wins }}</p>
+          </div>
+        </div>
+      </div>
+      <div class="col-md-3">
+        <div class="card text-center text-danger">
+          <div class="card-body">
+            <h5 class="card-title">Losses</h5>
+            <p class="card-text fs-4">{{ losses }}</p>
+          </div>
+        </div>
+      </div>
+      <div class="col-md-3">
+        <div class="card text-center text-secondary">
+          <div class="card-body">
+            <h5 class="card-title">Draws</h5>
+            <p class="card-text fs-4">{{ draws }}</p>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="row mb-4">
+      <div class="col-md-3">
+        <div class="card text-center text-info">
+          <div class="card-body">
+            <h5 class="card-title">Win Rate</h5>
+            <p class="card-text fs-4">{{ win_rate|floatformat:2 }}%</p>
+          </div>
+        </div>
+      </div>
+      <div class="col-md-3">
+        <div class="card text-center text-warning">
+          <div class="card-body">
+            <h5 class="card-title">Incomplete</h5>
+            <p class="card-text fs-4">{{ incomplete }}</p>
+          </div>
+        </div>
+      </div>
+    </div>
     {% if entries %}
       <div class="table-responsive">
         <table class="table table-bordered table-hover align-middle">
@@ -28,14 +96,17 @@
                   {% endif %}
                 </td>
                 <td>
+                  {# GameHistory.WIN = 0, GameHistory.DRAW = 1, GameHistory.LOSE = 2, GameHistory.INCOMPLETE = 3 #}
                   {% if record.result == 0 %}
-                    <span class="badge bg-secondary">Draw</span>
+                    <span class="badge bg-success">Win</span> {# Assuming 0 is Win based on common game dev practice, check model #}
                   {% elif record.result == 1 %}
-                    <span class="badge bg-success">Win</span>
+                    <span class="badge bg-secondary">Draw</span>
                   {% elif record.result == 2 %}
                     <span class="badge bg-danger">Lose</span>
+                  {% elif record.result == 3 %}
+                    <span class="badge bg-info text-dark">Incomplete</span>
                   {% else %}
-                    <span class="badge bg-secondary">N/A</span>
+                    <span class="badge bg-light text-dark">N/A</span>
                   {% endif %}
                 </td>
               </tr>
@@ -45,7 +116,7 @@
       </div>
     {% else %}
       <div class="alert alert-warning text-center mt-4" role="alert">
-        🎮 No game history found for this game yet. Time to start playing!
+        🎮 No game history found for the selected period. Time to start playing!
       </div>
     {% endif %}
   </div>


### PR DESCRIPTION
This pull request resolves Issue #1184 and #1439 by adding time-period filtering and statistics to the game history page. 

Changes:
- Backend (chigame/games/views.py): Updated game_history_view to filter GameHistory entries by a period (e.g., 7 days, 30 days, all time) and calculate statistics (wins, losses, draws, win rate) for that period.

- Frontend (chigame/templates/games/game_history.html): Added a dropdown to select the time period. Displayed the calculated statistics in cards and updated the match list based on the selected period. Improved result badge accuracy.


**How to Test:**

1. Log in and ensure you have game history entries with varied dates and results for a game (way easier to do this via /admin/ page then actually playing out games)
2. Go to that game's "View Game History" page.
3. Default View: Verify "All Time" stats and all matches are shown.
4. Period Dropdown: Select different periods (e.g., "Last 7 Days", "Last 30 Days"). Confirm stats and match list update correctly.
5. No Data: If no games fall into a selected period, check for zeroed stats and the "No game history found..." message.
6. Result Badges: Confirm "Win", "Lose", "Draw", "Incomplete" badges in the table are accurate.

![Screenshot 2025-05-27 at 5 40 06 PM](https://github.com/user-attachments/assets/404d41bc-cff5-42da-9b33-9a06777b2c0f)
