### PR TITLE
[Game Management] Initializing Game List UI Additons

### DIFF
--- a/src/chigame/users/views.py
+++ b/src/chigame/users/views.py
@@ -14,7 +14,7 @@ from django.views.decorators.http import require_POST
 from django.views.generic import DetailView, RedirectView, UpdateView
 from django_tables2 import SingleTableView
 
-from chigame.games.models import Lobby, Player, Tournament
+from chigame.games.models import GameList, Lobby, Player, Tournament
 
 from .models import (
     FriendInvitation,
@@ -199,7 +199,8 @@ def user_profile_detail_view(request, pk):
     if request.user.is_authenticated and request.user.pk == pk:
         # if user is accessing their own profile, create a profile if it doesn't exist
         profile = UserProfile.get_or_create_profile(request.user)
-        return render(request, "users/userprofile_detail.html", {"profile": profile})
+        game_lists = GameList.objects.filter(created_by=request.user)
+        return render(request, "users/userprofile_detail.html", {"profile": profile, "game_lists": game_lists})
     else:
         # fetch another user's profile
         try:

--- a/src/templates/games/gamelist_detail.html
+++ b/src/templates/games/gamelist_detail.html
@@ -1,28 +1,73 @@
 {% extends "base.html" %}
 
+{% load static %}
+
 {% block title %}
   {{ gamelist.name }}
 {% endblock title %}
 {% block content %}
   <div class="container mt-4">
-    <h1>{{ gamelist.name }}</h1>
+    <div class="d-flex justify-content-between align-items-center mb-3">
+      <h1>{{ gamelist.name }}</h1>
+      <div>
+        {% if gamelist.name != "Favorites" %}
+          {# Add Rename and Delete buttons here if desired in the future #}
+          {# For now, let's keep it simple #}
+        {% endif %}
+        <a href="{% url 'game-list' %}" class="btn btn-outline-primary">Browse More Games</a>
+      </div>
+    </div>
     {% if gamelist.description %}<p class="lead">{{ gamelist.description }}</p>{% endif %}
     {% if gamelist.games.all %}
-      <ul class="list-group mt-3">
+      <div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-4 mt-3">
         {% for game in gamelist.games.all %}
-          <li class="list-group-item d-flex justify-content-between align-items-center">
-            <a href="{% url 'game-detail' game.pk %}">{{ game.name }}</a>
-            {# Optionally, add a button to remove from this specific list #}
-            <a href="{% url 'remove-from-gamelist' game.pk gamelist.pk %}"
-               class="btn btn-sm btn-outline-warning">Remove</a>
-          </li>
+          <div class="col">
+            <div class="card h-100 shadow-sm">
+              {% if game.image and game.image != "/static/images/no_picture_available.png" %}
+                <img src="{{ game.image }}"
+                     class="card-img-top"
+                     alt="{{ game.name }}"
+                     class="gamelist-card-img" />
+              {% else %}
+                <img src="{% static 'images/no_picture_available.png' %}"
+                     class="card-img-top"
+                     alt="No image available"
+                     class="gamelist-card-img" />
+              {% endif %}
+              <div class="card-body d-flex flex-column">
+                <h5 class="card-title">
+                  <a href="{% url 'game-detail' game.pk %}">{{ game.name }}</a>
+                </h5>
+                <p class="card-text text-muted small">
+                  Players: {{ game.min_players }} - {{ game.max_players }}
+                  {% if game.expected_playtime %}
+                    <br />
+                    Playtime: {{ game.expected_playtime }} min
+                  {% endif %}
+                </p>
+                <div class="mt-auto d-flex justify-content-end">
+                  <a href="{% url 'remove-from-gamelist' game.pk gamelist.pk %}"
+                     class="btn btn-sm btn-outline-danger">Remove</a>
+                </div>
+              </div>
+            </div>
+          </div>
         {% endfor %}
-      </ul>
+      </div>
     {% else %}
-      <p class="mt-3">
+      <p class="mt-3 lead text-center">
         This list is empty. <a href="{% url 'game-list' %}">Browse games</a> to add some!
       </p>
     {% endif %}
-    <a href="{% url 'game-list' %}" class="btn btn-primary mt-4">Back to Games</a>
+    <div class="mt-4 text-center">
+      <a href="{% url 'users:user-profile' request.user.pk %}"
+         class="btn btn-secondary">Back to My Profile</a>
+    </div>
   </div>
+  <style>
+    .gamelist-card-img {
+      height: 200px;
+      object-fit: cover;
+    }
+  </style>
 {% endblock content %}

--- a/src/templates/users/user_detail.html
+++ b/src/templates/users/user_detail.html
@@ -3,16 +3,25 @@
 {% load static %}
 
 {% block title %}
-  My Details:
+  User Details: {{ object.username }}
 {% endblock title %}
 {% block content %}
   <div class="container">
-    <div class="row">
-      <div class="col-sm-12">
-        <h2>My Account:</h2>
-      </div>
-    </div>
+    <h1>{{ object.name|default:object.username }}</h1>
+    <p>
+      <strong>Username:</strong> {{ object.username }}
+    </p>
+    <p>
+      <strong>Email:</strong> {{ object.email }}
+    </p>
+    <p>
+      <strong>Joined:</strong> {{ object.date_joined|date:"Y-m-d" }}
+    </p>
     {% if object == request.user %}
+      <a href="{% url 'account_email' %}" class="btn btn-primary">Manage Email</a>
+      <a href="{% url 'account_change_password' %}" class="btn btn-primary">Change Password</a>
+      {# Link to the more detailed profile page #}
+      <a href="{% url 'users:user-profile' object.pk %}" class="btn btn-info">View Full Profile</a>
       <!-- Action buttons -->
       <style>
         .list-item {
@@ -119,6 +128,5 @@
       <!-- Display a message or take a different action -->
       <p>This account does not belong to you. Access is forbidden.</p>
     {% endif %}
-    <!-- End Action buttons -->
   </div>
 {% endblock content %}

--- a/src/templates/users/userprofile_detail.html
+++ b/src/templates/users/userprofile_detail.html
@@ -215,6 +215,29 @@
             </div>
           </div>
         </div>
+        {% if profile.user == request.user %}
+          <div class="card mt-4">
+            <div class="card-header">
+              <h3>My Game Lists</h3>
+            </div>
+            <div class="card-body">
+              {% if game_lists %}
+                <ul class="list-group list-group-flush">
+                  {% for game_list in game_lists %}
+                    <li class="list-group-item">
+                      <a href="{% url 'gamelist-detail' game_list.pk %}">{{ game_list.name }}</a>
+                      <span class="badge bg-secondary rounded-pill float-end">{{ game_list.games.count }} game{{ game_list.games.count|pluralize }}</span>
+                    </li>
+                  {% endfor %}
+                </ul>
+              {% else %}
+                <p class="text-muted">
+                  You don't have any game lists yet. <a href="{% url 'game-list' %}">Browse games</a> to create some!
+                </p>
+              {% endif %}
+            </div>
+          </div>
+        {% endif %}
       </div>
     </div>
   </div>


### PR DESCRIPTION
This pull request resolves Issue #1482 by enhancing game list accessibility and UI.

Key Changes:
- Game lists are now accessible from the user's profile page (users/profile/id/).
- Implemented a nicer looking card layout for the games/gamelists/id/ view
- - Each game card displays its image (with fallback, some games don't have images), player count, playtime, and a "Remove" button.
- Improved Navigation: Added "Back to My Profile" and "Browse More Games" links on the game list detail page.

**How to Test:**
1. Profile Page Game Lists:
- Log in and navigate to your profile
- Verify the "My Game Lists" section displays all your lists, each linking to its detail page.
- Confirm game counts are shown next to each list name.
2. Game List Detail View UI:
- Open a game list.
- Confirm the card layout on games/gamelists/<id>/.
- Verify correct display of game images (with placeholders), player count, playtime, and the "Remove" button.
- Test "Browse More Games" and "Back to My Profile" links.
- Ensure empty lists display an appropriate message and a link to browse games.