### PR TITLE
[achievements] Error Fix to ensure the constant view for Mac and Windows

### DIFF
--- a/src/static/css/achievements.css
+++ b/src/static/css/achievements.css
@@ -63,9 +63,9 @@
 
     .recent-achievements-tab {
       position: absolute;
-      top: 15%;
-      right: 15%;
-      width: 20%;
+      top: 15vh;
+      right: 15vw;
+      width: 20vw;
       background-color: var(--accent);
       color: white;
       padding: 10px 20px;
@@ -80,9 +80,10 @@
 
     .recent-achievements-box {
       position: absolute;
-      top: 21%;
-      right: 15%;
-      width: 20%;
+      top: 21vh;
+      right: 15vw;
+      width: 20vw;
+      max-height: 28vh;
       background-color: var(--card-bg);
       border-radius: 0 0 5px 5px;
       box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);


### PR DESCRIPTION
The "Recent Achievement" box had a positioning issue on the achievement page. I changed its positioning from using percentage values (e.g., top: 80%) to viewport height units (e.g., top: 80vh) to ensure consistency across different screen sizes.